### PR TITLE
Adds a boolean toggle for lowvram use

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -65,6 +65,8 @@ class SVDModelLoader:
         if lowvram:
             print('Using lowvram mode; calling half() on model')
             self.svd_model.model.half()
+        else:
+            self.svd_model.model.cuda()
 
         return (self.svd_model,)
 

--- a/nodes.py
+++ b/nodes.py
@@ -36,6 +36,7 @@ class SVDModelLoader:
                     "min" : 0,
                 }),
                 "device" : (devices,),
+                "lowvram": ("BOOLEAN", {"default": False}),
             },
         }
 
@@ -45,7 +46,7 @@ class SVDModelLoader:
 
     CATEGORY = "ComfyUI Stable Video Diffusion"
 
-    def load_svd_model(self, checkpoint, num_frames, num_steps, device):
+    def load_svd_model(self, checkpoint, num_frames, num_steps, device, lowvram):
         if self.svd_model is not None:
             del self.svd_model
             gc.collect()
@@ -60,6 +61,11 @@ class SVDModelLoader:
             num_steps=num_steps,
             checkpoint=checkpoint,
         )
+
+        if lowvram:
+            print('Using lowvram mode; calling half() on model')
+            self.svd_model.model.half()
+
         return (self.svd_model,)
 
 class SVDSampler:


### PR DESCRIPTION
Hello!

I've had great success at setting `lowvram_mode = True` in the Generative Models app from Stability AI when first trying out SVD: https://github.com/Stability-AI/generative-models/blob/main/scripts/demo/streamlit_helpers.py#L61-L75. In my experience I can run SVDxt at less than 24GB vram use on my 4090 with this enabled, whereas without I go _just_ over 24GB, triggering shared GPU ram use and greatly reducing performance.

This PR introduces a simple toggle to trigger half precision when used.