### PR TITLE
Update prestartup_script.py

### DIFF
--- a/prestartup_script.py
+++ b/prestartup_script.py
@@ -17,4 +17,4 @@ existing_svd_models = os.listdir(svd_models_dir)
 for model_name, model_url in SVD_MODEL_URLS.items():
     if model_name not in existing_svd_models:
         print(f"Downloading SVD model: {model_name}...")
-        os.system(f'wget -q --show-progress -O {os.path.join(svd_models_dir, model_name)} "{model_url}"')
+        os.system(f'wget -q --progress=bar -O {os.path.join(svd_models_dir, model_name)} "{model_url}"')


### PR DESCRIPTION
GNU wget "--show-progress" option does not exist in the windows version thus throws and error and doesn't download the models. Use "--progress=bar" instead.